### PR TITLE
NPE fix on animal damaged by lightning

### DIFF
--- a/src/main/java/com/wildmobsmod/entity/ai/EntityAIBabyPanic.java
+++ b/src/main/java/com/wildmobsmod/entity/ai/EntityAIBabyPanic.java
@@ -52,7 +52,7 @@ public class EntityAIBabyPanic extends EntityAIBase
 		while(iterator.hasNext())
 		{
 			EntityCreature entitycreature = (EntityCreature) iterator.next();
-			if(this.creature != entitycreature && entitycreature.getAttackTarget() == null && ((EntityAnimal) entitycreature).getAge() >= 0 && !entitycreature.isOnSameTeam(this.creature.getAITarget()) && this.creature.worldObj.rand.nextInt(2) == 0)
+			if(this.creature != entitycreature && entitycreature.getAttackTarget() == null && ((EntityAnimal) entitycreature).getAge() >= 0 && (this.creature.getAITarget() != null && !entitycreature.isOnSameTeam(this.creature.getAITarget())) && this.creature.worldObj.rand.nextInt(2) == 0)
 			{
 				entitycreature.setAttackTarget(this.creature.getAITarget());
 			}


### PR DESCRIPTION
Description: Ticking entity

java.lang.NullPointerException: Ticking entity
	at net.minecraft.entity.EntityLivingBase.func_142014_c(EntityLivingBase.java:2355)
	at com.wildmobsmod.entity.ai.EntityAIBabyPanic.func_75249_e(EntityAIBabyPanic.java:55)
	at net.minecraft.entity.ai.EntityAITasks.func_75774_a(SourceFile:94)
	at net.minecraft.entity.EntityLiving.func_70619_bc(EntityLiving.java:582)
	at net.minecraft.entity.EntityLivingBase.func_70636_d(EntityLivingBase.java:2066)
	at net.minecraft.entity.EntityLiving.func_70636_d(EntityLiving.java:388)
	at net.minecraft.entity.EntityAgeable.func_70636_d(EntityAgeable.java:144)
	at net.minecraft.entity.passive.EntityAnimal.func_70636_d(SourceFile:37)
	at net.minecraft.entity.EntityLivingBase.func_70071_h_(EntityLivingBase.java:1899)
	at net.minecraft.entity.EntityLiving.func_70071_h_(EntityLiving.java:213)
	at net.minecraft.world.World.func_72866_a(World.java:2674)
	at net.minecraft.world.WorldServer.func_72866_a(WorldServer.java:800)
	at net.minecraft.world.World.func_72870_g(World.java:2623)
	at net.minecraft.world.World.func_72939_s(World.java:2423)
	at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:633)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:954)
	at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:431)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:809)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:669)
	at java.lang.Thread.run(Thread.java:748)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Stacktrace:
	at net.minecraft.entity.EntityLivingBase.func_142014_c(EntityLivingBase.java:2355)
	at com.wildmobsmod.entity.ai.EntityAIBabyPanic.func_75249_e(EntityAIBabyPanic.java:55)
	at net.minecraft.entity.ai.EntityAITasks.func_75774_a(SourceFile:94)
	at net.minecraft.entity.EntityLiving.func_70619_bc(EntityLiving.java:582)
	at net.minecraft.entity.EntityLivingBase.func_70636_d(EntityLivingBase.java:2066)
	at net.minecraft.entity.EntityLiving.func_70636_d(EntityLiving.java:388)
	at net.minecraft.entity.EntityAgeable.func_70636_d(EntityAgeable.java:144)
	at net.minecraft.entity.passive.EntityAnimal.func_70636_d(SourceFile:37)
	at net.minecraft.entity.EntityLivingBase.func_70071_h_(EntityLivingBase.java:1899)
	at net.minecraft.entity.EntityLiving.func_70071_h_(EntityLiving.java:213)
	at net.minecraft.world.World.func_72866_a(World.java:2674)
	at net.minecraft.world.WorldServer.func_72866_a(WorldServer.java:800)
	at net.minecraft.world.World.func_72870_g(World.java:2623)

-- Entity being ticked --
Details:
	Entity Type: wildmobsmod.Bison (com.wildmobsmod.entity.passive.bison.EntityBison)
	Entity ID: 6576
	Entity Name: Bison
	Entity's Exact location: 1836.79, 68.00, -809.16
	Entity's Block location: World: (1836,68,-810), Chunk: (at 12,4,6 in 114,-51; contains blocks 1824,0,-816 to 1839,255,-801), Region: (3,-2; contains chunks 96,-64 to 127,-33, blocks 1536,0,-1024 to 2047,255,-513)
	Entity's Momentum: 0.00, -0.08, 0.00
Stacktrace:
	at net.minecraft.world.World.func_72939_s(World.java:2423)
	at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:633)
